### PR TITLE
Fixes for Docker image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+STREAMLIT_SECRETS_PATH="path/to/.streamlit/secrets.toml"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,15 +44,6 @@ jobs:
         uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
         with:
           cosign-release: 'v2.2.4'
-      - name: Create .env file
-        run: |
-          echo "rapid_api_key=${{ secrets.RAPID_API_KEY }}" >> .streamlit/secrets.toml
-          echo "openai_api_key=${{ secrets.OPENAI_API_KEY }}" >> .streamlit/secrets.toml
-          echo "qdrant_api_key=${{ secrets.QDRANT_API_KEY }}" >> .streamlit/secrets.toml
-          echo "qdrant_url=${{ secrets.QDRANT_URL }}" >> .streamlit/secrets.toml
-          echo "supa_key=${{ secrets.SUPA_KEY }}" >> .streamlit/secrets.toml
-          echo "supa_url=${{ secrets.SUPA_URL }}" >> .streamlit/secrets.toml
-          echo "courier_auth_token=${{ secrets.COURIER_AUTH_TOKEN }}" >> .streamlit/secrets.toml
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.11.9-slim-bookworm
 
 WORKDIR /app
 ADD . /app
-COPY ./.streamlit/secrets.toml /app/.streamlit/
+RUN mkdir -p /app/.streamlit
 
 RUN apt update && apt install -y gcc g++
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,77 @@
 # Beans AI🫘
 
 Find out about sustainability in your favorite sport clothing brands, in just one click!
+
+### For users
+
+Go to https://beans-ai.streamlit.app and feel free to explore the product from there!
+
+### For developers
+
+**1. Build from source**
+
+You can build the app from source by:
+
+- Cloning this repo:
+
+```bash
+git clone https://github.com/AstraBert/beans-ai
+cd beans-ai
+```
+
+- Create a virtual environment and activate it:
+
+```bash
+python3 -m venv streamlit-app
+source streamlit-app/bin/activate
+```
+
+- Install the required dependencies:
+
+```bash
+python3 -m pip install -r requirements.txt
+```
+
+- Build your `.streamlit/secrets.toml` file like this:
+
+```bash
+rapid_api_key="RAPID_API_KEY"
+openai_api_key="OPENAI_API_KEY"
+qdrant_api_key="QDRANT_API_KEY"
+qdrant_url="QDRANT_URL"
+courier_auth_token="COURIER_AUTH_TOKEN"
+supa_key="SUPABASE_ANON_KEY"
+supa_url="SUPABASE_URL"
+```
+- Run the application:
+
+```bash
+python3 -m streamlit run app.py
+```
+
+**2. Use the Docker image**
+
+There is a Docker image available on the GitHub Container Registry at `ghcr.io/astrabert/beans-ai`. 
+
+You can choose two ways to use the Docker image:
+
+- _From the pre-built image_: 
+    + Pull the image: we advise you pull the `main` tag, as it is on track with the latest modifications to the app
+    ```bash
+    docker pull ghcr.io/astrabert/beans-ai:main
+    ```
+    + Create a `.streamlit/secrets.toml` as specified in the previous section
+    + Create a `.env` file and specify the path to `.streamlit/secrets.toml` under the `STREAMLIT_SECRETS_PATH` variable
+    + Launch docker compose and find the app http://localhost:8501:
+    ```bash
+    docker compose up -d
+    ```
+- _Build the image yourself_ (**assuming you have cloned the repository and you are inside it**): 
+    + Create a `.streamlit/secrets.toml` as specified in the previous section
+    + Create a `.env` file and specify the path to `.streamlit/secrets.toml` under the `STREAMLIT_SECRETS_PATH` variable
+    + Launch docker compose with the build option and find the app http://localhost:8501:
+    ```bash
+    docker compose -f compose.build.yaml up -d
+    ```
+
+Find an example of the `.env` file on [`.env.example`](./.env.example)

--- a/compose.build.yaml
+++ b/compose.build.yaml
@@ -1,0 +1,9 @@
+services:
+  app:
+    build: 
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - $STREAMLIT_SECRETS_PATH:/app/.streamlit/secrets.toml
+    ports:
+      - "8501:8501"

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,7 @@
+services:
+  app:
+    image: ghcr.io/astrabert/beans-ai:main
+    volumes:
+      - $STREAMLIT_SECRETS_PATH:/app/.streamlit/secrets.toml
+    ports:
+      - "8501:8501"


### PR DESCRIPTION
Closes #1 

- Use `docker compose` instead of `docker run`
- Secrets are defined by the user  and provided as volume to the compose mount
- Docs for developers